### PR TITLE
Added to the bottom of .gitignore for some Apple housekeeping.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,10 @@ ENV/
 # vim
 *.swp
 *.swo
+
+# MacOS files
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+


### PR DESCRIPTION
Put a few items at the bottom the .gitignore because Apple leaves a few files on the local drive that don't mean anything useful when they get copied.